### PR TITLE
Update authorization policy for GetAllStops endpoint

### DIFF
--- a/backend/API/Endpoints/StopManagement/StopManagementApi.cs
+++ b/backend/API/Endpoints/StopManagement/StopManagementApi.cs
@@ -12,7 +12,7 @@ public static class StopManagementApi
             .WithName(nameof(StopManagementEndpoints.GetAllStops))
             .WithDescription("Get all Stops")
             .Produces<List<StopWithAssignmentsAndDivisionsDto>>()
-            .RequireAuthorization(Setup.AdminPolicyName);
+            .RequireAuthorization(Setup.TeacherOrAdminPolicyName);
 
         group.MapGet("stops", StopManagementEndpoints.GetPublicStops)
             .WithName(nameof(StopManagementEndpoints.GetPublicStops))


### PR DESCRIPTION
Changed the authorization requirement for the GetAllStops endpoint from AdminPolicyName to TeacherOrAdminPolicyName to allow access for both teachers and admins.