### PR TITLE
Redesign stops page with advanced filtering

### DIFF
--- a/dashboard/src/app/pages/stops/stops.component.html
+++ b/dashboard/src/app/pages/stops/stops.component.html
@@ -1,75 +1,108 @@
-<div class="top-10 flex justify-center px-10 pt-2 mt-5">
-  <button
-    (click)="showGroupPopUp(-1)"
-    class="mr-5 btn btn-primary"
-  >
-    Add StopGroup
-  </button>
-  <button [routerLink]="['/stop']" class="mr-5 btn btn-primary">
-    Add Stop
-  </button>
-  <app-filter [elements]="divisionStore.getDivisions()" (filter)="divisionFilter.set($event)"></app-filter>
-</div>
-<div>
-  <div class="m-5 p-5">
-    @for (stop of filteredStops(); track $index) {
-      <div
-        class="w-100 border-transparents m-2 mx-32 mb-10 justify-between rounded-lg dark:border dark:border-accent-400 bg-background-100 p-6 text-text-950 shadow-lg shadow-secondary-200"
-      >
-        <div class="flex flex-nowrap justify-between">
-          <p class="font-bold">{{ stop.name }}</p>
-          <button
-            class="mr-5 btn btn-primary"
-            [routerLink]="['/stop']"
-            [queryParams]="{ id: stop.id }"
-          >
-            Details
-          </button>
-        </div>
+<div class="m-4 flex flex-col items-center text-text-950">
+  <h2 class="my-6 text-2xl font-bold self-center">Stops Overview</h2>
 
-        @if (stop.stopGroupIds.length > 0) {
-          <div class="mt-5 rounded-xl p-5 shadow-lg shadow-secondary-200 dark:border dark:border-accent-400">
-            <p class="text-xl">Stopgroups</p>
-            @for (sgId of stop.stopGroupIds; track $index) {
-              @if (getGroupById(sgId)) {
-                <div class="flex flex-nowrap justify-between pl-5 pt-5">
-                  <p>{{ getGroupById(sgId)?.name }}</p>
-                  <div>
-                    <button
-                      class="mr-5 btn btn-outline btn-error shadow-lg"
-                      (click)="selectStopgroupToRemove(stop.id, sgId)"
-                    >
-                      Remove
-                    </button>
-                    <button
-                      class="my-1 btn btn-primary"
-                      (click)="showGroupPopUp(sgId)"
-                    >
-                      Details
-                    </button>
-                  </div>
-                </div>
-              }
-            }
-          </div>
+  <!-- Action Buttons -->
+  <div class="flex justify-center gap-4 mb-6">
+    <button [routerLink]="['/stop']" class="btn btn-primary">
+      Add Stop
+    </button>
+    <button (click)="clearFilters()" class="btn btn-outline hover:btn-primary">
+      Clear Filters
+    </button>
+  </div>
+
+  <!-- Filters Section -->
+  <div class="flex flex-wrap gap-4 mb-4 mx-4">
+    <!-- Stop Name Search -->
+    <div class="form-control">
+      <label class="label">
+        <span class="label-text">Stop Name Filter</span>
+      </label>
+      <input type="text" placeholder="Search stop names..."
+             class="input placeholder-black input-bordered w-full max-w-xs bg-primary-300 hover:bg-primary-400"
+             [(ngModel)]="stopNameSearchTerm"/>
+    </div>
+
+    <!-- Stop Group Filter -->
+    <div class="form-control">
+      <label class="label">
+        <span class="label-text">Stop Group Filter</span>
+      </label>
+      <select class="select select-bordered w-full max-w-xs bg-primary-300 hover:bg-primary-400"
+              [(ngModel)]="stopGroupFilter">
+        <option value="">All Stop Groups</option>
+        @for (groupName of uniqueStopGroups(); track groupName) {
+          <option [value]="groupName">{{ groupName }}</option>
         }
-      </div>
-    }
+      </select>
+    </div>
+
+    <!-- Teacher Search -->
+    <div class="form-control">
+      <label class="label">
+        <span class="label-text">Responsible Teachers Filter</span>
+      </label>
+      <input type="text" placeholder="Search teachers..."
+             class="input placeholder-black input-bordered w-full max-w-xs bg-primary-300 hover:bg-primary-400"
+             [(ngModel)]="teacherSearchTerm"/>
+    </div>
+
+    <!-- Division Filter (existing functionality) -->
+    <div class="form-control">
+      <label class="label">
+        <span class="label-text">Department Filter</span>
+      </label>
+      <app-filter [elements]="divisionStore.getDivisions()" (filter)="divisionFilter.set($event)"></app-filter>
+    </div>
+  </div>
+
+  <!-- Stops Table -->
+  <div
+    class="overflow-x-auto w-full max-w-6xl mt-6 table-zebra table-lg rounded-box border border-base-content/5 bg-base-100 max-h-[600px] overflow-y-scroll">
+    <table class="table table-xs">
+      <thead>
+      <tr>
+        <th>Stop Name</th>
+        <th>Stop Group</th>
+        <th>Room</th>
+        <th>Responsible Teachers</th>
+        <th>Department</th>
+        <th>Students (Requested/Assigned)</th>
+        <th>Actions</th>
+      </tr>
+      </thead>
+      <tbody>
+        @if (filteredStops().length === 0) {
+          <tr>
+            <td colspan="7" class="text-center">No stops found</td>
+          </tr>
+        } @else {
+          @for (stop of filteredStops(); track stop.id) {
+            <tr>
+              <td class="font-semibold">{{ stop.name }}</td>
+              <td>{{ getStopGroupNames(stop.stopGroupIds) }}</td>
+              <td>{{ stop.roomNr || 'No room assigned' }}</td>
+              <td>{{ getTeacherNames(stop.id) }}</td>
+              <td>{{ getDivisionNames(stop.divisionIds) }}</td>
+              <td>{{ getStudentCount(stop.id) }}</td>
+              <td>
+                <button
+                  class="btn btn-sm btn-info"
+                  [routerLink]="['/stop']"
+                  [queryParams]="{ id: stop.id }"
+                >
+                  Details
+                </button>
+              </td>
+            </tr>
+          }
+        }
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Summary Information -->
+  <div class="mt-4 text-sm text-gray-600">
+    Showing {{ filteredStops().length }} of {{ stopStore.stops().length }} stops
   </div>
 </div>
-
-@if (showRemoveStopgroupPopup()) {
-  <app-delete-popup
-    [title]="'Remove Stopgroup'"
-    [message]="'Are you sure you want to remove this stop from the stop group?'"
-    (cancel)="showRemoveStopgroupPopup.set(false)"
-    (removeConfirmed)="removeStopgroup()"
-  />
-}
-
-@if (showGroupDetailPopUp()) {
-  <app-stopgroup-details
-    [id]="groupIdDetail"
-    (cancel)="showGroupDetailPopUp.set(false)"
-  />
-}

--- a/dashboard/src/app/pages/stops/stops.component.ts
+++ b/dashboard/src/app/pages/stops/stops.component.ts
@@ -1,59 +1,121 @@
-import { Component, computed, inject, OnInit, signal } from '@angular/core';
-import { Stop, StopGroup } from '../../types';
-import { RouterModule } from '@angular/router';
-import { FilterComponent } from '../../standard-components/filter/filter.component';
-import { DeletePopupComponent } from '../../popups/delete-popup/delete-popup.component';
-import { StopStore } from '../../store/stop.store';
-import { StopGroupStore } from '../../store/stopgroup.store';
-import { DivisionStore } from '../../store/division.store';
-import { StopgroupDetailsComponent } from '../../detail-pages/stopgroup-details/stopgroup-details.component';
+import {Component, computed, inject, signal} from '@angular/core';
+import {Status, StopGroup} from '../../types';
+import {RouterModule} from '@angular/router';
+import {FilterComponent} from '../../standard-components/filter/filter.component';
+import {StopStore} from '../../store/stop.store';
+import {StopGroupStore} from '../../store/stopgroup.store';
+import {DivisionStore} from '../../store/division.store';
+import {TeacherStore} from '../../store/teacher.store';
+import {StudentStore} from '../../store/student.store';
+import {FormsModule} from '@angular/forms';
 
 @Component({
   selector: 'app-stops',
   standalone: true,
-  imports: [RouterModule, FilterComponent, DeletePopupComponent, StopgroupDetailsComponent],
+  imports: [RouterModule, FilterComponent, FormsModule],
   templateUrl: './stops.component.html',
 })
 export class StopsComponent {
-  private stopStore = inject(StopStore);
+  protected stopStore = inject(StopStore);
   private stopGroupStore = inject(StopGroupStore);
+  private teacherStore = inject(TeacherStore);
+  private studentStore = inject(StudentStore);
   protected divisionStore = inject(DivisionStore);
 
+  // Filter signals
   divisionFilter = signal<number>(0);
-  showRemoveStopgroupPopup = signal<boolean>(false);
+  stopNameSearchTerm = signal<string>('');
+  stopGroupFilter = signal<string>('');
+  teacherSearchTerm = signal<string>('');
 
-  stopGroupIdToRemove: number = -1;
-  stopIdFromRemove: number = -1;
 
-  showGroupDetailPopUp = signal<boolean>(false);
-  groupIdDetail: number = -1;
+  // Computed properties for filters and data
+  uniqueStopGroups = computed(() => {
+    const stopGroups = this.stopGroupStore.stopGroups();
+    return [...new Set(stopGroups.map(sg => sg.name))].sort();
+  });
 
-  filteredStops = computed(() => this.stopStore.filterStopsByDivisionId(this.divisionFilter()));
+  filteredStops = computed(() => {
+    let stops = this.stopStore.filterStopsByDivisionId(this.divisionFilter());
 
-  async deleteStop(stopId: number) {
-    await this.stopStore.deleteStop(stopId);
-  }
+    // Filter by stop name
+    const nameSearch = this.stopNameSearchTerm().toLowerCase();
+    if (nameSearch) {
+      stops = stops.filter(stop => stop.name.toLowerCase().includes(nameSearch));
+    }
+
+    // Filter by stop group
+    const stopGroupName = this.stopGroupFilter();
+    if (stopGroupName) {
+      const stopGroup = this.stopGroupStore.stopGroups().find(sg => sg.name === stopGroupName);
+      if (stopGroup) {
+        stops = stops.filter(stop => stop.stopGroupIds.includes(stopGroup.id));
+      }
+    }
+
+    // Filter by teacher
+    const teacherSearch = this.teacherSearchTerm().toLowerCase();
+    if (teacherSearch) {
+      stops = stops.filter(stop => {
+        const teachers = this.getTeachersByStopId(stop.id);
+        return teachers.some(teacher =>
+          teacher.firstName.toLowerCase().includes(teacherSearch) ||
+          teacher.lastName.toLowerCase().includes(teacherSearch) ||
+          `${teacher.firstName} ${teacher.lastName}`.toLowerCase().includes(teacherSearch)
+        );
+      });
+    }
+
+    return stops;
+  });
 
   getGroupById(sgId: number): StopGroup | null {
     return this.stopGroupStore.stopGroups().find((sg) => sg.id === sgId) || null;
   }
 
-  async selectStopgroupToRemove(stopId: number, sgId: number) {
-    this.stopGroupIdToRemove = sgId;
-    this.stopIdFromRemove = stopId;
-    this.showRemoveStopgroupPopup.set(true);
+  getStopGroupNames(stopGroupIds: number[]): string {
+    const names = stopGroupIds
+      .map(id => this.getGroupById(id)?.name)
+      .filter(name => name)
+      .join(', ');
+    return names || 'No groups assigned';
   }
 
-  async removeStopgroup() {
-    const stopToUpdate: Stop = this.stopStore.stops().find((s) => s.id === this.stopIdFromRemove)!;
-    stopToUpdate.stopGroupIds = stopToUpdate.stopGroupIds.filter((sgId) => sgId !== this.stopGroupIdToRemove);
-    await this.stopStore.updateStop(stopToUpdate);
-    this.showRemoveStopgroupPopup.set(false);
+  getTeachersByStopId(stopId: number) {
+    return this.teacherStore.getTeachersByStopId(stopId);
   }
 
-  showGroupPopUp(id: number): void {
-    this.groupIdDetail = id;
-    this.showGroupDetailPopUp.set(true);
+  getTeacherNames(stopId: number): string {
+    const teachers = this.getTeachersByStopId(stopId);
+    if (teachers.length === 0) return 'No teachers assigned';
+    return teachers.map(t => `${t.firstName} ${t.lastName}`).join(', ');
   }
 
+  getStudentCount(stopId: number): string {
+    const students = this.studentStore.getStudentsByStopId(stopId);
+    const requested = students.filter(s =>
+      s.studentAssignments.some(a => a.stopId === stopId && a.status === Status.Pending)
+    ).length;
+    const assigned = students.filter(s =>
+      s.studentAssignments.some(a => a.stopId === stopId && a.status === Status.Accepted)
+    ).length;
+    return `${requested} / ${assigned}`;
+  }
+
+  getDivisionNames(divisionIds: number[]): string {
+    const divisions = this.divisionStore.getDivisions();
+    const names = divisionIds
+      .map(id => divisions.find(d => d.id === id)?.name)
+      .filter(name => name)
+      .join(', ');
+    return names || 'No departments';
+  }
+
+  // Reset filters
+  clearFilters(): void {
+    this.stopNameSearchTerm.set('');
+    this.stopGroupFilter.set('');
+    this.teacherSearchTerm.set('');
+    this.divisionFilter.set(0);
+  }
 }


### PR DESCRIPTION
Revamps the stops overview page UI to use a table layout and adds multiple filter options: stop name, stop group, responsible teachers, and department. Implements corresponding filter logic in the component, summary info, and a clear filters button for improved usability.